### PR TITLE
Raise TOL as get_scale_param is very fast

### DIFF
--- a/taildropout.py
+++ b/taildropout.py
@@ -4,15 +4,16 @@ from torch import Tensor
 from typing import Union, List, Optional
 from math import exp
 
-def get_scale_param(p=0.5, tol=1e-6) -> float:
+def get_scale_param(p, tol=1e-9) -> float:
     """ Numerically solve integral equation int_0^1 S(x) dx = p
         with S survival function for exponential distribution.
 
         use a - a * exp(-1 / a) = int_0^1 S(x) dx = p
         <=> a = p/(1 - exp(-1/a)) fixed point form 
-        and just iterate a=f(a) until convergence
+        and just iterate a=g(a) until convergence
 
-        This is an arbitrary and naive way of calculating it.
+        This is a naive way of calculating it.
+        But fast (nano-microseconds)
     """
     assert p!=0 and p!=1
 

--- a/test.py
+++ b/test.py
@@ -110,14 +110,14 @@ def test_grad():
         y.sum().backward()
         assert x.grad.detach().equal(y.detach())
 
-        x.grad = None  # Modern way to zero gradients
+        x.grad = None
         y = dropout(x)
         y.sum().backward()
         assert x.grad.detach().equal(y.detach())
         x.grad = None
 
 def test_get_scale_param():
-    tol=1e-6
+    tol=1e-10
     for p_expected in [0.000001, 0.00001, 0.0001, 0.001, 0.01, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]:
         a = get_scale_param(p_expected,tol)
         p_actual = a - a * exp(-1 / a)  # int_0^1 S(x) dx


### PR DESCRIPTION
https://github.com/ragulpr/taildropout/blob/20319ac6d2a0cd51aea7cafd4c3f91d72ba8eae8/taildropout.py#L7
https://github.com/ragulpr/taildropout/blob/20319ac6d2a0cd51aea7cafd4c3f91d72ba8eae8/taildropout.py#L86-L93

I first considered the risk of what happens when creating many instances of TailDropout (big network) and having to call the function many times. I considered doing something like caching results:
```
from functools import lru_cache

@lru_cache(maxsize=None) 
def get_scale_param(p, tol=1e-9) -> float:
...
```
But then I timed it and it turns out it's vanishingly fast so no need to optimize.
```
%%timeit
get_scale_param(p=0.5, tol=1e-10)
# 7.66 µs ± 86.5 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each) # tol 1e-10
```