### PR TITLE
Auto-upcast and reshape mask

### DIFF
--- a/taildropout.py
+++ b/taildropout.py
@@ -135,15 +135,16 @@ class TailDropout(nn.Module):
             device = input.device
 
             linspace = torch.arange(1, n_features + 1, 1, device=device, dtype=type_out)
-            prob_shape = replace_w_ones_except(input.shape, self.dropout_dim) #[1,1,..,n_features]
-            linspace.resize_(prob_shape)
             # self.scale*n_features faster than linspace/n_features
             prob = self.cdf(linspace, self.scale * n_features)
+
+            prob_shape = replace_w_ones_except(input.shape, self.dropout_dim) #[1,1,..,n_features]
+            prob = prob.reshape(prob_shape)
 
             mask_shape = replace_w_ones_except(input.shape, self.batch_dim)
             uniform = torch.rand(mask_shape, device=device, dtype=type_out) # [n_batch,1,1] if input 3d
             mask = prob < uniform         # 43% of cpu cumtime                [n_batch,1,n_features] 
-            mask = mask.type(type_out)    # 30% of cpu cumtime
+            # mask = mask.type(type_out)    # 30% of cpu cumtime
             return input * mask           # 23% of cpu cumtime # Note works due to broadcasting
             # Similar performance / identical with torch.compile but doesn't propagate NaN:
             # inv_mask = prob >= uniform
@@ -154,14 +155,11 @@ class TailDropout(nn.Module):
         
         if mode == 'first_k':
             # Do mask[:, :, (...), :, k:] = 0 in choice of dropout_dim
-            mask_shape = replace_w_ones_except(input.shape, self.dropout_dim)
-            mask = input.new_ones(*mask_shape)
-            slices = [slice(None)] * input.ndim
+            mask = input.new_ones(n_features)
+            mask[self.k:] = 0
 
-            # Avoid recompilation for every k
-            with torch._dynamo.config.patch({"disable": True}):
-                slices[self.dropout_dim] = slice(self.k, None)
-                mask[tuple(slices)] = 0
+            mask_shape = replace_w_ones_except(input.shape, self.dropout_dim)
+            mask = mask.reshape(mask_shape)
 
             return input * mask
         


### PR DESCRIPTION
On GPU it runs as;

```
y = torch.randn(512,128,512, requires_grad=True,device='cuda')
dropout = TailDropout().cuda()
optimizer = torch.optim.SGD((y,), lr=0.1)
# dropout.compile()
for _ in range(1000):
  z = dropout(y)
  loss = z.sum()
  loss.backward()
  optimizer.step()
  optimizer.zero_grad()
```
```
%%timeit
for _ in range(1000):
  z = dropout(y)
  loss = z.sum()
  loss.backward()
  optimizer.step()
  optimizer.zero_grad()

# 4.03 s ± 1.59 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)# new
# 4.04 s ± 743 µs per loop (mean ± std. dev. of 7 runs, 1 loop each) # new
# 5.09 s ± 843 µs per loop (mean ± std. dev. of 7 runs, 1 loop each) # Compiled


# 4.05 s ± 1.25 ms per loop (mean ± std. dev. of 7 runs, 1 loop each) # old
# 5.08 s ± 715 µs per loop (mean ± std. dev. of 7 runs, 1 loop each) # Old compiled

```