### PR TITLE
Use `set_buffer` to avoid repeated recompiles. Branch on boolean is_k_set. Dont compile on torch 2.2.2

### DIFF
--- a/taildropout.py
+++ b/taildropout.py
@@ -176,12 +176,12 @@ class TailDropout(nn.Module):
             raise ValueError(f"TailDropout k ({self.k}) is greater than n_features ({n_features})")
 
         # Do mask[:, :, (...), :, k:] = 0 in choice of dropout_dim
-        # mask = input.new_ones(n_features, dtype=torch.bool)
-        # mask[self.k:] = 0
-        mask = torch.arange(n_features, device=input.device, dtype=torch.int64) < self.k
+        mask = input.new_ones(n_features, dtype=torch.bool)
+        mask[self.k:] = 0
+        # mask = torch.arange(n_features, device=input.device, dtype=torch.int64) < self.k
 
         mask_shape = replace_w_ones_except(input.shape, self.dropout_dim)
-        mask = mask.reshape(mask_shape)
+        mask = mask.reshape(mask_shape) # Ex [1,1,n_features]
         return input * mask
 
     def extra_repr(self) -> str:

--- a/taildropout.py
+++ b/taildropout.py
@@ -182,6 +182,7 @@ class TailDropout(nn.Module):
 
         mask_shape = replace_w_ones_except(input.shape, self.dropout_dim)
         mask = mask.reshape(mask_shape) # Ex [1,1,n_features]
+        # TODO try input.masked_fill(inv_mask, 0)
         return input * mask
 
     def extra_repr(self) -> str:

--- a/taildropout.py
+++ b/taildropout.py
@@ -154,7 +154,7 @@ class TailDropout(nn.Module):
 
         raise ValueError
 
-    @torch.compiler.disable()
+    # @torch.compiler.disable()
     def _first_k_mask(self, input) -> Tensor:
         n_features = input.shape[self.dropout_dim]
         if self.k > n_features:

--- a/taildropout.py
+++ b/taildropout.py
@@ -90,7 +90,6 @@ class TailDropout(nn.Module):
         # exponential distribution
         self.cdf = lambda x, scale: 1 - torch.exp(-x / scale)
         self.set_p(p)
-        self.register_buffer('k', torch.tensor(-1, dtype=torch.long))
         self.set_k(None)
         self.k_is_set = False  # Flag to track if k has been initialized
 
@@ -102,11 +101,10 @@ class TailDropout(nn.Module):
             self.scale = get_scale_param(p)
 
     def set_k(self, k: Optional[int]):
+        self.k = k
         if k is None:
-            self.k.fill_(-1)
             self.k_is_set = False
         else:
-            self.k.fill_(k)
             self.k_is_set = True
 
     def train(self, mode=True):

--- a/taildropout.py
+++ b/taildropout.py
@@ -169,9 +169,9 @@ class TailDropout(nn.Module):
             raise ValueError(f"TailDropout k ({self.k}) is greater than n_features ({n_features})")
 
         # Do mask[:, :, (...), :, k:] = 0 in choice of dropout_dim
-        mask = input.new_ones(n_features, dtype=torch.bool)
-        mask[self.k:] = 0
-        # mask = torch.arange(n_features, device=input.device, dtype=torch.int64) < self.k
+        # mask = input.new_ones(n_features, dtype=torch.bool)
+        # mask[self.k:] = 0
+        mask = torch.arange(n_features, device=input.device, dtype=torch.int64) < self.k
 
         mask_shape = replace_w_ones_except(input.shape, self.dropout_dim)
         mask = mask.reshape(mask_shape)

--- a/taildropout.py
+++ b/taildropout.py
@@ -147,7 +147,7 @@ class TailDropout(nn.Module):
             # return input.masked_fill(inv_mask, 0)
         
         if mode == 'first_k':
-            return input * self._first_k_mask(input)
+            return input * self._first_k_mask(input, self.k)
             
         if mode == 'zero':
             return input * 0
@@ -155,16 +155,16 @@ class TailDropout(nn.Module):
         raise ValueError
 
     # @torch.compiler.disable()
-    def _first_k_mask(self, input) -> Tensor:
+    def _first_k_mask(self, input : Tensor, k : int) -> Tensor:
         n_features = input.shape[self.dropout_dim]
-        if self.k > n_features:
-            raise ValueError(f"TailDropout k ({self.k}) is greater than n_features ({n_features})")
+        if k > n_features:
+            raise ValueError(f"TailDropout k ({k}) is greater than n_features ({n_features})")
 
         
         # Do mask[:, :, (...), :, k:] = 0 in choice of dropout_dim
         # mask = input.new_ones(n_features, dtype=torch.bool)
-        # mask[self.k:] = 0
-        mask = torch.arange(n_features, device=input.device, dtype=torch.int64) < self.k # Alt.
+        # mask[k:] = 0
+        mask = torch.arange(n_features, device=input.device, dtype=torch.int64) < k # Alt.
         
         mask_shape = replace_w_ones_except(input.shape, self.dropout_dim)
         mask = mask.reshape(mask_shape)

--- a/taildropout.py
+++ b/taildropout.py
@@ -91,13 +91,24 @@ class TailDropout(nn.Module):
         self.cdf = lambda x, scale: 1 - torch.exp(-x / scale)
         self.set_p(p)
         self.set_k(None)
-
+        self.register_forward_pre_hook(self._k_default_hook)
+                
     def set_p(self, p)->None:
         self._p = p
         if p == 0 or p == 1:
             self.scale = None
         else:
             self.scale = get_scale_param(p)
+
+    def _k_default_hook(self, module, args):
+        if len(args)==2:
+            # x, k = args
+            return args
+        elif len(args)==1:
+            (x,) = args
+            return (x, self.k)
+        else:
+            raise ValueError('Too many args to forward')
 
     def set_k(self, k : Optional[int]) :
         self.k = k
@@ -114,8 +125,8 @@ class TailDropout(nn.Module):
             self.set_k(None)
         return super().eval()
     
-    def forward(self, input: Tensor) -> Tensor:
-        if self.k is None:
+    def forward(self, input: Tensor, k : Optional[int] = None) -> Tensor:
+        if k is None:
             if self.training:
                 if self._p == 0:
                     mode = 'straight-through'
@@ -154,7 +165,7 @@ class TailDropout(nn.Module):
             # return input.masked_fill(inv_mask, 0)
         
         if mode == 'first_k':
-            return self._first_k_call(input)
+            return self._first_k_call(input, k)
             
         if mode == 'zero':
             return input * 0
@@ -162,16 +173,16 @@ class TailDropout(nn.Module):
         raise ValueError
 
     @disable_torch_2_2_compilation
-    def _first_k_call(self, input : Tensor) -> Tensor:
+    def _first_k_call(self, input : Tensor, k : int) -> Tensor:
         n_features = input.shape[self.dropout_dim]
 
-        if self.k > n_features:
-            raise ValueError(f"TailDropout k ({self.k}) is greater than n_features ({n_features})")
+        if k > n_features:
+            raise ValueError(f"TailDropout k ({k}) is greater than n_features ({n_features})")
 
         # Do mask[:, :, (...), :, k:] = 0 in choice of dropout_dim
         mask = input.new_ones(n_features, dtype=torch.bool)
-        mask[self.k:] = 0
-        # mask = torch.arange(n_features, device=input.device, dtype=torch.int64) < self.k
+        mask[k:] = 0
+        # mask = torch.arange(n_features, device=input.device, dtype=torch.int64) < k
 
         mask_shape = replace_w_ones_except(input.shape, self.dropout_dim)
         mask = mask.reshape(mask_shape)

--- a/taildropout.py
+++ b/taildropout.py
@@ -92,7 +92,6 @@ class TailDropout(nn.Module):
         self.set_p(p)
         self.register_buffer('k', torch.tensor(-1, dtype=torch.long))
         self.set_k(None)
-        self.k_is_set = False  # Flag to track if k has been initialized
 
     def set_p(self, p)->None:
         self._p = p
@@ -104,25 +103,23 @@ class TailDropout(nn.Module):
     def set_k(self, k: Optional[int]):
         if k is None:
             self.k.fill_(-1)
-            self.k_is_set = False
         else:
             self.k.fill_(k)
-            self.k_is_set = True
 
     def train(self, mode=True):
-        if self.k_is_set:
+        if self.k>=0:
             warnings.warn("Calling .train() resets `self.k={self.k}` to None")
             self.set_k(None)
         return super().train(mode)
 
     def eval(self):
-        if self.k_is_set:
+        if self.k>=0:
             warnings.warn("Calling .eval() resets `self.k={self.k}` to None")
             self.set_k(None)
         return super().eval()
     
     def forward(self, input: Tensor) -> Tensor:
-        if not self.k_is_set:
+        if self.k==-1:
             if self.training:
                 if self._p == 0:
                     mode = 'straight-through'

--- a/taildropout.py
+++ b/taildropout.py
@@ -147,7 +147,7 @@ class TailDropout(nn.Module):
             # return input.masked_fill(inv_mask, 0)
         
         if mode == 'first_k':
-            return self._first_k_call(input)
+            return input * self._first_k_mask(input)
             
         if mode == 'zero':
             return input * 0
@@ -155,7 +155,7 @@ class TailDropout(nn.Module):
         raise ValueError
 
     @torch.compiler.disable()
-    def _first_k_call(self, input):
+    def _first_k_mask(self, input) -> Tensor:
         n_features = input.shape[self.dropout_dim]
         if self.k > n_features:
             raise ValueError(f"TailDropout k ({self.k}) is greater than n_features ({n_features})")
@@ -168,7 +168,7 @@ class TailDropout(nn.Module):
         
         mask_shape = replace_w_ones_except(input.shape, self.dropout_dim)
         mask = mask.reshape(mask_shape)
-        return input * mask
+        return mask
 
     def extra_repr(self) -> str:
         return f'p={self._p}, batch_dim={self.batch_dim}, dropout_dim={self.dropout_dim}, k={self.k}'

--- a/taildropout.py
+++ b/taildropout.py
@@ -90,6 +90,7 @@ class TailDropout(nn.Module):
         # exponential distribution
         self.cdf = lambda x, scale: 1 - torch.exp(-x / scale)
         self.set_p(p)
+        self.register_buffer('k', torch.tensor(-1, dtype=torch.long))
         self.set_k(None)
         self.k_is_set = False  # Flag to track if k has been initialized
 
@@ -101,10 +102,11 @@ class TailDropout(nn.Module):
             self.scale = get_scale_param(p)
 
     def set_k(self, k: Optional[int]):
-        self.k = k
         if k is None:
+            self.k.fill_(-1)
             self.k_is_set = False
         else:
+            self.k.fill_(k)
             self.k_is_set = True
 
     def train(self, mode=True):

--- a/taildropout.py
+++ b/taildropout.py
@@ -162,9 +162,9 @@ class TailDropout(nn.Module):
 
         
         # Do mask[:, :, (...), :, k:] = 0 in choice of dropout_dim
-        mask = input.new_ones(n_features, dtype=torch.bool)
-        mask[self.k:] = 0
-        # mask = torch.arange(n_features, device=device, dtype=torch.int64) < self.k # Alt.
+        # mask = input.new_ones(n_features, dtype=torch.bool)
+        # mask[self.k:] = 0
+        mask = torch.arange(n_features, device=input.device, dtype=torch.int64) < self.k # Alt.
         
         mask_shape = replace_w_ones_except(input.shape, self.dropout_dim)
         mask = mask.reshape(mask_shape)

--- a/taildropout.py
+++ b/taildropout.py
@@ -92,6 +92,7 @@ class TailDropout(nn.Module):
         self.set_p(p)
         self.register_buffer('k', torch.tensor(-1, dtype=torch.long))
         self.set_k(None)
+        self.k_is_set = False  # Flag to track if k has been initialized
 
     def set_p(self, p)->None:
         self._p = p
@@ -103,23 +104,25 @@ class TailDropout(nn.Module):
     def set_k(self, k: Optional[int]):
         if k is None:
             self.k.fill_(-1)
+            self.k_is_set = False
         else:
             self.k.fill_(k)
+            self.k_is_set = True
 
     def train(self, mode=True):
-        if self.k>=0:
+        if self.k_is_set:
             warnings.warn("Calling .train() resets `self.k={self.k}` to None")
             self.set_k(None)
         return super().train(mode)
 
     def eval(self):
-        if self.k>=0:
+        if self.k_is_set:
             warnings.warn("Calling .eval() resets `self.k={self.k}` to None")
             self.set_k(None)
         return super().eval()
     
     def forward(self, input: Tensor) -> Tensor:
-        if self.k==-1:
+        if not self.k_is_set:
             if self.training:
                 if self._p == 0:
                     mode = 'straight-through'

--- a/taildropout.py
+++ b/taildropout.py
@@ -172,17 +172,20 @@ class TailDropout(nn.Module):
     @disable_torch_2_2_compilation
     def _first_k_call(self, input : Tensor) -> Tensor:
         n_features = input.shape[self.dropout_dim]
-
+        type_out = input.dtype
+        device = input.device
         if self.k > n_features:
             raise ValueError(f"TailDropout k ({self.k}) is greater than n_features ({n_features})")
 
-        # Do mask[:, :, (...), :, k:] = 0 in choice of dropout_dim
-        mask = input.new_ones(n_features, dtype=torch.bool)
-        mask[self.k:] = 0
-        # mask = torch.arange(n_features, device=input.device, dtype=torch.int64) < self.k
+        linspace = torch.arange(1, n_features + 1, 1, device=device, dtype=type_out)
 
-        mask_shape = replace_w_ones_except(input.shape, self.dropout_dim)
-        mask = mask.reshape(mask_shape) # Ex [1,1,n_features]
+        prob_shape = replace_w_ones_except(input.shape, self.dropout_dim) #[1,1,..,n_features]
+        noise_shape = replace_w_ones_except(input.shape, self.batch_dim)  #[n_batch,1,1] if input 3d         
+
+        linspace = linspace.reshape(prob_shape)
+        uniform = torch.ones(noise_shape, device=device, dtype=type_out).fill_(self.k+1)
+        
+        mask = linspace < uniform
         return input * mask
 
     def extra_repr(self) -> str:

--- a/taildropout.py
+++ b/taildropout.py
@@ -147,7 +147,7 @@ class TailDropout(nn.Module):
             # return input.masked_fill(inv_mask, 0)
         
         if mode == 'first_k':
-            return input * self._first_k_mask(input, self.k)
+            return input * self._first_k_mask(input, torch.tensor(self.k))
             
         if mode == 'zero':
             return input * 0
@@ -155,7 +155,7 @@ class TailDropout(nn.Module):
         raise ValueError
 
     # @torch.compiler.disable()
-    def _first_k_mask(self, input : Tensor, k : int) -> Tensor:
+    def _first_k_mask(self, input : Tensor, k : Tensor) -> Tensor:
         n_features = input.shape[self.dropout_dim]
         if k > n_features:
             raise ValueError(f"TailDropout k ({k}) is greater than n_features ({n_features})")

--- a/taildropout.py
+++ b/taildropout.py
@@ -160,10 +160,12 @@ class TailDropout(nn.Module):
         if self.k > n_features:
             raise ValueError(f"TailDropout k ({self.k}) is greater than n_features ({n_features})")
 
+        
         # Do mask[:, :, (...), :, k:] = 0 in choice of dropout_dim
         mask = input.new_ones(n_features, dtype=torch.bool)
         mask[self.k:] = 0
-
+        # mask = torch.arange(n_features, device=device, dtype=torch.int64) < self.k # Alt.
+        
         mask_shape = replace_w_ones_except(input.shape, self.dropout_dim)
         mask = mask.reshape(mask_shape)
         return input * mask

--- a/test.py
+++ b/test.py
@@ -226,24 +226,24 @@ def test_recompilation():
     # Measure how many new graphs got compiled. Use "<=" to cover multiple torch versions + GPU
     # Forward pass - no grad
     _check_routes(dropout=model, input_shape=(10, 5, 3), requires_grad=False)  # noqa
-    assert len(compile_counter.graphs) <= 2
+    assert len(compile_counter.graphs) <= 3
 
     # Repeated calls
     for _ in range(5):
         _check_routes(dropout=model, input_shape=(10, 5, 3), requires_grad=False)  # noqa
-        assert len(compile_counter.graphs) <= 3
+        assert len(compile_counter.graphs) <= 4
 
     # Forward + Backward pass
     for _ in range(5):
         _check_routes(dropout=model, input_shape=(10, 5, 3), requires_grad=True)  # noqa
-        assert len(compile_counter.graphs) <= 3
+        assert len(compile_counter.graphs) <= 6
 
     # Forward + Backward pass - Prime @ train
     model.train()
     model(torch.ones((10, 5, 3)).to(DEVICE))
     for _ in range(5):
         _check_routes(dropout=model, input_shape=(10, 5, 3), requires_grad=True)  # noqa
-        assert len(compile_counter.graphs) <= 3
+        assert len(compile_counter.graphs) <= 6
 
     # Forward + Backward pass - Prime @ eval
     model = torch.compile(TailDropout(), backend=compile_counter)
@@ -251,7 +251,7 @@ def test_recompilation():
     model(torch.ones((10, 5, 3)).to(DEVICE))
     for _ in range(5):
         _check_routes(dropout=model, input_shape=(10, 5, 3), requires_grad=True)  # noqa
-        assert len(compile_counter.graphs) <= 3
+        assert len(compile_counter.graphs) <= 6
 
 def test_compilation_set_k(): # FAILS
     torch.compiler.reset()
@@ -278,7 +278,7 @@ def test_compilation_set_k(): # FAILS
             model.set_k(k)
             y = model(x)
             assert y.sum()==k,(y,k)
-    assert len(compile_counter.graphs) <= f
+    assert len(compile_counter.graphs) <= 2
 
 
 # print('test_expected_mask',test_expected_mask())

--- a/test.py
+++ b/test.py
@@ -226,10 +226,10 @@ def test_recompilation():
     # Measure how many new graphs got compiled. Use "<=" to cover multiple torch versions + GPU
     # Forward pass - no grad
     _check_routes(dropout=model, input_shape=(10, 5, 3), requires_grad=False)  # noqa
-    assert len(compile_counter.graphs) <= 6
+    assert len(compile_counter.graphs) <= 2
 
     # Repeated calls
-    for _ in range(10):
+    for _ in range(5):
         _check_routes(dropout=model, input_shape=(10, 5, 3), requires_grad=False)  # noqa
         assert len(compile_counter.graphs) <= 3
 

--- a/test.py
+++ b/test.py
@@ -253,7 +253,7 @@ def test_recompilation():
         _check_routes(dropout=model, input_shape=(10, 5, 3), requires_grad=True)  # noqa
         assert len(compile_counter.graphs) <= 6
 
-def test_compilation_set_k(): # FAILS
+def test_compilation_set_k():
     torch.compiler.reset()
     torch._dynamo.config.cache_size_limit = 1000 # Trick to not err out on recompile
     # torch._dynamo.config.verify_correctness = True # Fails with torch >2.2
@@ -267,9 +267,8 @@ def test_compilation_set_k(): # FAILS
     f = 16
     x = torch.ones(1, f, device = DEVICE, requires_grad=False)
     compile_counter = CompileCounterWithBackend("inductor")
-    model = TailDropout()
-    model = model.to(DEVICE)
-    model = torch.compile(model, backend=compile_counter, dynamic =False)
+    model = TailDropout().to(DEVICE)
+    model = torch.compile(model, backend=compile_counter, dynamic=False)
     with torch.no_grad():
         for k in range(f+1):
             # for _name, module in model.named_modules():

--- a/test.py
+++ b/test.py
@@ -226,10 +226,10 @@ def test_recompilation():
     # Measure how many new graphs got compiled. Use "<=" to cover multiple torch versions + GPU
     # Forward pass - no grad
     _check_routes(dropout=model, input_shape=(10, 5, 3), requires_grad=False)  # noqa
-    assert len(compile_counter.graphs) <= 2
+    assert len(compile_counter.graphs) <= 6
 
     # Repeated calls
-    for _ in range(5):
+    for _ in range(10):
         _check_routes(dropout=model, input_shape=(10, 5, 3), requires_grad=False)  # noqa
         assert len(compile_counter.graphs) <= 3
 


### PR DESCRIPTION
Using 

* Using `mask = torch.arange(n_features, device=input.device, dtype=torch.int64) < self.k` vs `mask[self.k:] = 0` has little effect on recompile
* Enabling/disabling assert has no effect 
* Using `set_buffer` seems to solve it for now. 
* Additionally - using explicit boolean flag seems to (marginally) lower number of recompiles/branches and is quite readable. Can be reevaluated later.
* Attempt to use same shape as train for k mask (i.e not optimize it) has no effect on recompile mem 

Remains to be figured out why there's excessive mem use after `set_k` is called, wip here https://github.com/ragulpr/modded-nanogpt/tree/egil/taildropout